### PR TITLE
Fix the polyfill to behave like the spec

### DIFF
--- a/polyfill.js
+++ b/polyfill.js
@@ -8,12 +8,14 @@ if (typeof Promise.prototype.finally !== 'function') {
 		var S = C[Symbol.species];
 		return S == null ?  defaultConstructor : S;
 	};
-	Promise.prototype.finally = function finally(onFinally) {
-		var handler = typeof onFinally === 'function' ? onFinally : () => {};
-		var C = speciesConstructor(this, Promise);
-		return this.then(
-			x => C.resolve(onFinally()).then(() => x),
-			e => C.resolve(onFinally()).then(() => throw e)
-		});
+	Object.assign(Promise.prototype, {
+		['finally'] (onFinally) {
+			var handler = typeof onFinally === 'function' ? onFinally : () => {};
+			var C = speciesConstructor(this, Promise);
+			return this.then(
+				x => C.resolve(handler()).then((v = x) => v),
+				e => C.resolve(handler()).then((v = e) => { throw v })
+			);
+		}
 	});
 }


### PR DESCRIPTION
Firstly, fixes syntax errors (extra brackets). Neither babel or v8 accepted `=> throw`, so wrap that in brackets.

This portion of the spec was not being observed by the polyfill:

> However, please note: just like a syntactic finally, a non-undefined return in the finally callback will resolve the new promise to that value, and a throw (or returning a rejected promise) in the finally callback will reject the new promise with that rejection reason.

Running `Promise.resolve(3).finally(() => 4).then((v) => console.log(v))` with the (syntax fixed only) polyfill would print `3`; will print `4` with the fix.

The polyfill would check for `onFinally`'s type, provide a fallback, and then not use the result. Call the `handler` instead of `onFinally`, fixes `Promise.resolve().finally()`.

Unfortunately, `function finally` is a syntax error in both babel and v8, so use Object.assign trickery to produce a function with the appropriate name. Alternatives to the `Object.assign` hack would be either use a name other than `finally` for the function definition, or use an anonymous function.